### PR TITLE
make getSessionAndProfile() protected so we can overwrite it

### DIFF
--- a/lib/BxClient.php
+++ b/lib/BxClient.php
@@ -103,7 +103,7 @@ class BxClient
 		return $this->password;
 	}
 	
-	private function getSessionAndProfile() {
+	protected function getSessionAndProfile() {
 		
 		if($this->sessionId != null && $this->profileId != null) {
 			return array($this->sessionId, $this->profileId);


### PR DESCRIPTION
we will need to override the ``getSessionAndProfile()`` method to prevent issues with our own approach to handling sessions and cookies. easiest would be to extend the ``BxClient`` class accordingly.